### PR TITLE
Removed explicit example, to avoid recommending this use too much.

### DIFF
--- a/site/content/practices/2.0.md
+++ b/site/content/practices/2.0.md
@@ -231,19 +231,6 @@ copyright, you must:
  * take into account what kind of metadata version control systems store. For example,
    Git stores the committer and author in two different fields.
 
-An appropriate header in this case would be:
-
-```
- /*
-  * This file is part of project X. It's copyrighted by the contributors
-  * recorded in the version control history of the file, available from
-  * its original location http://git.example.com/X/filename.c
-  * 
-  * SPDX-License-Identifier: GPL-3.0
-  */
-```
-
-
 > ## Keep in mind
 > 
 > * Use a consistent style of your headers throughout the project.


### PR DESCRIPTION
This change removes the explicit example when it comes to using vcs, in the hope it will not be understood as a clear recommendation to use vcs. This changes the focus to highlight more the concerns with vcs use, rather than how to do it.

I would consider this a mere editorial change that doesn't change the specification itself, so no need to version it. But happy to take input from @silverhook on it.