### PR TITLE
Communicate that submodules and Meson subprojects are ignored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Remove symlinks and zero-byte files from list of Covered Files. (#101)
 
+- Remove submodules from list of Covered Files. (#99)
+
 - Clarify which license text files are needed if a SPDX license expression
   contains more than one license and/or exception. (#96)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,7 @@ The versions follow [semantic versioning](https://semver.org).
 
 - Remove symlinks and zero-byte files from list of Covered Files. (#101)
 
-- Remove submodules from list of Covered Files. (#99)
+- Remove submodules and Meson subprojects from list of Covered Files. (#99)
 
 - Clarify which license text files are needed if a SPDX license expression
   contains more than one license and/or exception. (#96)

--- a/spec.md
+++ b/spec.md
@@ -41,8 +41,8 @@ These are the definitions for some of the terms used in this specification:
       `.git/`).
     - The files ignored by the version control system (example: files listed in
       `.gitignore`).
-    - Submodules of the Project's version control system. Each submodule is
-      understood as a separate Project.
+    - Submodules of the Project's version control system and Meson subprojects.
+      Each submodule and Meson subproject is understood as a separate Project.
     - The files in the `.reuse/` directory in the root of the Project. This
       directory MUST contain only files relevant for the operation of the REUSE
       Tool.

--- a/spec.md
+++ b/spec.md
@@ -41,6 +41,8 @@ These are the definitions for some of the terms used in this specification:
       `.git/`).
     - The files ignored by the version control system (example: files listed in
       `.gitignore`).
+    - Submodules of the Project's version control system. Each submodule is
+      understood as a separate Project.
     - The files in the `.reuse/` directory in the root of the Project. This
       directory MUST contain only files relevant for the operation of the REUSE
       Tool.


### PR DESCRIPTION
Fixes #129 and the spec side of #36

To finalise this, fsfe/reuse-tool#514 would still be missing (display ignored submodules in summary).