### PR TITLE
Ignore symlinks and zero-byte files

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -44,6 +44,7 @@ These are the definitions for some of the terms used in this specification:
     - The files in the `.reuse/` directory in the root of the Project. This
       directory MUST contain only files relevant for the operation of the REUSE
       Tool.
+    - Symlinks and files with no data (zero-byte).
 
 - SPDX Specification --- SPDX specification, version 2.1; as available on
   <https://spdx.org/specifications>.


### PR DESCRIPTION
Fixes #63 

It's on one line because both file types are very similar. Should we be nitpicky and make two bullet points out of it?