### PR TITLE
Introduce a stable branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,36 +9,40 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 [![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 [![REUSE compliant](https://reuse.software/badge/reuse-compliant.svg)](https://reuse.software/)
 
-We're working to make managing copyrights and licenses in free and open
-source software easier. This is a collection of tutorials, FAQs and specifications to demonstrate how
-to add copyright and license information to a project in ways which allow
-for more automation.
+We're working to make managing copyrights and licenses in free and open source
+software easier. This is a collection of tutorials, FAQs and specifications to
+demonstrate how to add copyright and license information to a project in ways
+which allow for more automation.
 
 ## Install
 
-There's no installation here, only the plain text documents. The sister repository [reuse-website](https://github.com/fsfe/reuse-website) includes this repository as a submodule to display it on [reuse.software](https://reuse.software).
+There's no installation here, only the plain text documents. The sister
+repository [reuse-website](https://github.com/fsfe/reuse-website) includes this
+repository as a submodule to display it on
+[reuse.software](https://reuse.software).
 
 ## Usage
 
-Go to [reuse.software](https://reuse.software) and enjoy :-) If your project follows the reuse
-guidelines, we encourage you to show that in your `README.md` and similar! Just register your
-project with the [REUSE API](https://api.reuse.software/) and copy the resulting badge code in
-your README file.
+Go to [reuse.software](https://reuse.software) and enjoy :-) If your project
+follows the reuse guidelines, we encourage you to show that in your `README.md`
+and similar! Just register your project with the [REUSE
+API](https://api.reuse.software/) and copy the resulting badge code in your
+README file.
 
 ## Contribute
 
-We'd love to get feedback on these practices, ideally in the form
-of pull requests which we can discuss around.
+We'd love to get feedback on these practices, ideally in the form of pull
+requests which we can discuss around.
 
-We also accept and appreciate feedback by creating issues in the
-project or by sending an e-mail to the [public REUSE mailing
+We also accept and appreciate feedback by creating issues in the project or by
+sending an e-mail to the [public REUSE mailing
 list](https://lists.fsfe.org/mailman/listinfo/reuse).
 
 ### Translation
 
 Translation happens by conversion Markdown into _gettext_ using
-[po4a](https://po4a.org).  To generate the _.md_ files from the
-_gettext .po_ files, run:  `po4a po/po4a.conf`.
+[po4a](https://po4a.org).  To generate the _.md_ files from the _gettext .po_
+files, run:  `po4a po/po4a.conf`.
 
 ### Branches
 
@@ -49,4 +53,5 @@ the spec are "backported" to the `stable` branch.
 
 ## License
 
-The relevant documents in this repository are licensed under [Creative Commons Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0).
+The relevant documents in this repository are licensed under [Creative Commons
+Attribution-ShareAlike 4.0](https://creativecommons.org/licenses/by-sa/4.0).

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 [![REUSE compliant](https://reuse.software/badge/reuse-compliant.svg)](https://reuse.software/)
 
 We're working to make managing copyrights and licenses in free and open
-source software easier. This is a collection of tutorials, FAQs and specifications to demonstrate how 
+source software easier. This is a collection of tutorials, FAQs and specifications to demonstrate how
 to add copyright and license information to a project in ways which allow
 for more automation.
 
@@ -39,6 +39,13 @@ list](https://lists.fsfe.org/mailman/listinfo/reuse).
 Translation happens by conversion Markdown into _gettext_ using
 [po4a](https://po4a.org).  To generate the _.md_ files from the
 _gettext .po_ files, run:  `po4a po/po4a.conf`.
+
+### Branches
+
+The latest official specification release is in the `stable` branch, while the
+main branch (`master`) contains fixes and new and potentially breaking
+specification changes. Typically, non-spec changes or insignificant fixes for
+the spec are "backported" to the `stable` branch.
 
 ## License
 


### PR DESCRIPTION
Especially if we work on revolutionary features for the spec (like snippets or REUSE.yaml), it would be good to separate the development from a stable branch.

Instead of using a moving tag, which is somewhat hacky, I propose a `stable` branch in which we can backport/cherry-pick translations, FAQ items etc easily.

This stable branch can then be the basis for the submodule in reuse-website.