### PR TITLE
Specify encoding of .license files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The versions follow [semantic versioning](https://semver.org).
 - Introduce support of in-line snippet comments using
   `SPDX-SnippetBegin`/`SPDX-SnippetEnd`. (#107)
 
+- Specify encoding of `.license` files to UTF-8. (#106, thanks @kirelagin for
+  the helpful background information)
+
 - Introduce `REUSE-IgnoreStart`/`REUSE-IgnoreEnd` to make the REUSE helper tool
   not consider the enclosed content for detecting copyright and licensing
   information. (#104)

--- a/spec.md
+++ b/spec.md
@@ -107,7 +107,7 @@ file's Copyright and Licensing Information.
 
 If a file is not a plain text file or does not permit the inclusion of
 comments, the comment header that declares the file's Copyright and Licensing
-Information SHOULD be in an adjacent file of the same name with the
+Information SHOULD be in an adjacent UTF-8 encoded text file of the same name with the
 additional extension `.license` (example: `cat.jpg.license` if the original
 file is `cat.jpg`).
 


### PR DESCRIPTION
Fixes #73 

I took the very simple suggestion by @kirelagin. @silverhook had some concerns regarding UTF-8 but if I understood correctly they were cleared. Please correct me if I'm wrong :)