### PR TITLE
Show '--force-dot-license' in tutorial

### DIFF
--- a/tutorial.md
+++ b/tutorial.md
@@ -142,11 +142,11 @@ The REUSE helper tool should automatically detect binary files and
 therefore automatically create a corresponding `.license` file.
 
 If it does not, or if you would like to enforce this, add the
-`--explicit-license` argument to the addheader command. So the command
+`--force-dot-license` argument to the addheader command. So the command
 for the above task may look like this:
 
 ```bash
-reuse addheader --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" --explicit-license img/cat.jpg img/dog.jpg
+reuse addheader --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" --force-dot-license img/cat.jpg img/dog.jpg
 ```
 
 {{< /box-tool >}}


### PR DESCRIPTION
rather than the deprecated --explicit-license