### PR TITLE
docs: DEP5 standard link in contex

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -191,6 +191,9 @@ file through a DEP5 file. The intended use case of this method is large
 directories where including a comment header in each file (or in `.license`
 companion files) is impossible or undesirable.
 
+The [DEP5 standard governed by Debian](https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/)
+determines the formatting requirements.
+
 The DEP5 file MUST be named `dep5` and stored in the `.reuse/` directory in the
 root of the Project (i.e. `.reuse/dep5`).
 


### PR DESCRIPTION
Also add a link to the DEP5 standard in the context of describing the DEP5 format, to make it easier to find additional formatting requirements. This is an improvement to address the confusion described in issue https://github.com/fsfe/reuse-tool/issues/631

Signed-off-by: Nico Rikken <nico@nicorikken.eu>