### PR TITLE
Formally allow using .license files with Commentable Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The versions follow [semantic versioning](https://semver.org).
 
 ### Added
 
+- Definition for Commentable and Uncommentable Files. (#123, thanks @Jayman2000)
+
 - Introduce support of in-line snippet comments using
   `SPDX-SnippetBegin`/`SPDX-SnippetEnd`. (#107)
 
@@ -44,6 +46,9 @@ The versions follow [semantic versioning](https://semver.org).
 - URLs to currently applicable SPDX specification. (#49)
 
 ### Changed
+
+- Allow `.license` files for commentable files, but strongly recommend adding
+  copyright/licensing information in header. (#123, thanks @Jayman2000)
 
 - Bump referenced SPDX version to 2.3, and update links. (#103) (#107)
 

--- a/spec.md
+++ b/spec.md
@@ -50,6 +50,11 @@ These are the definitions for some of the terms used in this specification:
       4.4](https://spdx.github.io/spdx-spec/conformance/#44-standard-data-format-requirements)
       (example: `sbom.spdx.json`).
 
+- Commentable File --- a plain text file that can contain comments.
+
+- Uncommentable File --- either a plain text file that cannot contain comments
+  or a file that is not a plain text file.
+
 - SPDX Specification --- SPDX specification, version 2.3; as available on
   <https://spdx.org/specifications>.
 
@@ -101,14 +106,13 @@ Information with a snippet.
 
 ### Comment headers
 
-To implement this method, each plain text file that can contain comments MUST
+To implement this method, each Commentable File MUST
 contain comments at the top of the file (comment header) that declare that
 file's Copyright and Licensing Information.
 
-If a file is not a plain text file or does not permit the inclusion of
-comments, the comment header that declares the file's Copyright and Licensing
-Information SHOULD be in an adjacent file of the same name with the
-additional extension `.license` (example: `cat.jpg.license` if the original
+For Uncommentable Files, the comment header that declares the file's Copyright
+and Licensing Information SHOULD be in an adjacent file of the same name with
+the additional extension `.license` (example: `cat.jpg.license` if the original
 file is `cat.jpg`).
 
 The comment header MUST contain one or more `SPDX-FileCopyrightText` tags, and one or

--- a/spec.md
+++ b/spec.md
@@ -106,7 +106,7 @@ Information with a snippet.
 
 ### Comment headers
 
-To implement this method, each Commentable File MUST
+To implement this method, each Commentable File SHOULD
 contain comments at the top of the file (comment header) that declare that
 file's Copyright and Licensing Information.
 
@@ -114,6 +114,9 @@ For Uncommentable Files, the comment header that declares the file's Copyright
 and Licensing Information SHOULD be in an adjacent file of the same name with
 the additional extension `.license` (example: `cat.jpg.license` if the original
 file is `cat.jpg`).
+
+`.license` files MAY be used with Commentable Files, but it is still RECOMMENDED
+that comment headers be put inside Commentable Files.
 
 The comment header MUST contain one or more `SPDX-FileCopyrightText` tags, and one or
 more `SPDX-License-Identifier` tags. A tag is followed by a colon, followed by


### PR DESCRIPTION
See individual commit messages for details.

Fixes #122.