### PR TITLE
Update deprecated commands

### DIFF
--- a/po/reuse-docs.cs.po
+++ b/po/reuse-docs.cs.po
@@ -1821,19 +1821,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Pokud tomu tak není, nebo pokud chcete tuto povinnost vynutit, přidejte do "
-"příkazu annotate argument `--explicit-license`. Příkaz pro výše uvedenou "
+"příkazu annotate argument `--force-dot-license`. Příkaz pro výše uvedenou "
 "úlohu tedy může vypadat takto:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
-".0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+".0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: tutorial.md

--- a/po/reuse-docs.cs.po
+++ b/po/reuse-docs.cs.po
@@ -1761,28 +1761,28 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
-"Příkaz `reuse addheader` vám pomůže přidat do souborů informace o licencích "
+"Příkaz `reuse annotate` vám pomůže přidat do souborů informace o licencích "
 "a autorských právech. Pro výše uvedenou úlohu by tuto úlohu splnil "
 "následující příkaz:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-or-later\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 "Další možnosti, například styly komentářů a šablony, naleznete v dokumentaci "
-"[nástroje addheader](https://reuse.readthedocs.io/en/stable/usage."
-"html#addheader)"
+"[nástroje annotate](https://reuse.readthedocs.io/en/stable/usage."
+"html#annotate)"
 
 #. type: Title ###
 #: tutorial.md
@@ -1821,18 +1821,18 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Pokud tomu tak není, nebo pokud chcete tuto povinnost vynutit, přidejte do "
-"příkazu addheader argument `--explicit-license`. Příkaz pro výše uvedenou "
+"příkazu annotate argument `--explicit-license`. Příkaz pro výše uvedenou "
 "úlohu tedy může vypadat takto:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
@@ -1882,11 +1882,11 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 "Nástroj zatím neposkytuje způsob, jak nahradit stávající informace o "
 "autorských právech a licencích v souladu s nařízením REUSE. Spuštění příkazu "
-"`addheader` by nenahradilo, ale rozšířilo by soubory `.license` o dva další "
+"`annotate` by nenahradilo, ale rozšířilo by soubory `.license` o dva další "
 "řádky uvádějící autorská práva Maxe Mehla a licenci CC-BY-4.0. Ty byste tedy "
 "museli aktualizovat ručně."
 
@@ -1976,20 +1976,20 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
-"Stejně jako dříve splní výše uvedený krok kombinace příkazů `addheader` a "
+"Stejně jako dříve splní výše uvedený krok kombinace příkazů `annotate` a "
 "`download`:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
 ".0\" .gitignore\n"
 "\n"
 "reuse download --all\n"

--- a/po/reuse-docs.de.po
+++ b/po/reuse-docs.de.po
@@ -1547,19 +1547,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1589,13 +1589,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1634,7 +1634,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1699,14 +1699,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.de.po
+++ b/po/reuse-docs.de.po
@@ -1589,13 +1589,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.el.po
+++ b/po/reuse-docs.el.po
@@ -1290,19 +1290,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1332,13 +1332,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1377,7 +1377,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1442,14 +1442,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.el.po
+++ b/po/reuse-docs.el.po
@@ -1332,13 +1332,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.eo.po
+++ b/po/reuse-docs.eo.po
@@ -1342,21 +1342,21 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
-"reuse addheader --copyright=\"Johanino Umo <johanino@example.com>\" "
+"reuse annotate --copyright=\"Johanino Umo <johanino@example.com>\" "
 "--license=\"GPL-3.0-or-later\" fonto/ĉefprogramo.c Makefile README.md\n"
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1389,15 +1389,15 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
-"reuse addheader --copyright=\"Johanino Umo <johanino@example.com>\" "
+"reuse annotate --copyright=\"Johanino Umo <johanino@example.com>\" "
 "--license=\"GPL-3.0-or-later\" --explicit-license bildo/kato.jpg bildo/hundo."
 "jpg\n"
 
@@ -1440,7 +1440,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1505,14 +1505,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.eo.po
+++ b/po/reuse-docs.eo.po
@@ -1389,16 +1389,16 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 "reuse annotate --copyright=\"Johanino Umo <johanino@example.com>\" "
-"--license=\"GPL-3.0-or-later\" --explicit-license bildo/kato.jpg bildo/hundo."
+"--license=\"GPL-3.0-or-later\" --force-dot-license bildo/kato.jpg bildo/hundo."
 "jpg\n"
 
 #. type: Title ###

--- a/po/reuse-docs.es.po
+++ b/po/reuse-docs.es.po
@@ -1744,7 +1744,7 @@ msgstr ""
 
 #. type: Plain text
 #: tutorial.md
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Si no es así, o si desea aplicar esto, agregue el argumento `--explicit-"
 "license` al comando annotate. Entonces, la orden para la tarea anterior se "
@@ -1753,10 +1753,10 @@ msgstr ""
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
-".0-o-posterior\" --explicit-license img/cat.jpg img/dog.jpg\n"
+".0-o-posterior\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: tutorial.md

--- a/po/reuse-docs.es.po
+++ b/po/reuse-docs.es.po
@@ -1688,26 +1688,26 @@ msgstr ""
 
 #. type: Plain text
 #: tutorial.md
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
-"La orden `reuse addheader` ayuda a agregar información de licencia y "
+"La orden `reuse annotate` ayuda a agregar información de licencia y "
 "derechos de autor a sus archivos. Para la tarea anterior, haría el trabajo "
 "la siguiente orden:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-o-posterior\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: tutorial.md
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
-"Consulte la [documentación de la herramienta sobre addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader)  para obtener más opciones, "
+"Consulte la [documentación de la herramienta sobre annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate)  para obtener más opciones, "
 "como estilos de comentarios y plantillas"
 
 #. type: Title ###
@@ -1744,18 +1744,18 @@ msgstr ""
 
 #. type: Plain text
 #: tutorial.md
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Si no es así, o si desea aplicar esto, agregue el argumento `--explicit-"
-"license` al comando addheader. Entonces, la orden para la tarea anterior se "
+"license` al comando annotate. Entonces, la orden para la tarea anterior se "
 "puede ver así:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-o-posterior\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
@@ -1799,11 +1799,11 @@ msgstr ""
 
 #. type: Plain text
 #: tutorial.md
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 "La herramienta a partir de ahora no proporciona una forma de reemplazar la "
 "información existente de REUSE compatible de licencia y derechos de autor. "
-"Una ejecución del comando `addheader` no reemplazaría sino que ampliaría los "
+"Una ejecución del comando `annotate` no reemplazaría sino que ampliaría los "
 "archivos `.license` con dos líneas adicionales que indican los derechos de "
 "autor de Max Mehl y la licencia CC-BY-4.0. Por lo tanto, tendría que "
 "actualizarlos manualmente."
@@ -1889,20 +1889,20 @@ msgstr ""
 
 #. type: Plain text
 #: tutorial.md
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
-"Como antes, una combinación de los comandos `addheader` y `download` "
+"Como antes, una combinación de los comandos `annotate` y `download` "
 "cumplirá el paso anterior:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
 ".0\" .gitignore \n"
 " \n"
 "reuse download --all\n"

--- a/po/reuse-docs.fr.po
+++ b/po/reuse-docs.fr.po
@@ -1846,27 +1846,27 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
-"La commande `reuse addheader` aide à ajouter des informations de licence et "
+"La commande `reuse annotate` aide à ajouter des informations de licence et "
 "de droit d'auteur à vos fichiers. Pour la tâche ci-dessus, la commande "
 "suivante ferait le travail :"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-or-later\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
-"Veuillez consulter la [documentation de l'outil sur addheader](https://reuse."
-"readthedocs.io/en/stable/usage.html#addheader) pour plus d'options comme les "
+"Veuillez consulter la [documentation de l'outil sur annotate](https://reuse."
+"readthedocs.io/en/stable/usage.html#annotate) pour plus d'options comme les "
 "styles de commentaires et les modèles"
 
 #. type: Title ###
@@ -1907,18 +1907,18 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Si ce n'est pas le cas, ou si vous souhaitez appliquer cela, ajoutez "
-"l'argument `--explicit-license` à la commande addheader. Ainsi, la commande "
+"l'argument `--explicit-license` à la commande annotate. Ainsi, la commande "
 "pour la tâche ci-dessus peut ressembler à ceci :"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
@@ -1967,11 +1967,11 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 "À l'heure actuelle, l'outil ne permet pas de remplacer les informations de "
 "copyright et de licence existantes conformes à REUSE. Une exécution de la "
-"commande `addheader` ne remplacerait pas mais étendrait les fichiers `."
+"commande `annotate` ne remplacerait pas mais étendrait les fichiers `."
 "license` avec deux lignes supplémentaires indiquant le copyright de Max Mehl "
 "et la licence CC-BY-4.0. Vous devrez donc les mettre à jour manuellement."
 
@@ -2064,20 +2064,20 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
-"Comme précédemment, une combinaison des commandes `addheader` et `download` "
+"Comme précédemment, une combinaison des commandes `annotate` et `download` "
 "remplira l'étape ci-dessus :"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
 ".0\" .gitignore\n"
 "\n"
 "reuse download --all\n"

--- a/po/reuse-docs.fr.po
+++ b/po/reuse-docs.fr.po
@@ -1907,19 +1907,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Si ce n'est pas le cas, ou si vous souhaitez appliquer cela, ajoutez "
-"l'argument `--explicit-license` à la commande annotate. Ainsi, la commande "
+"l'argument `--force-dot-license` à la commande annotate. Ainsi, la commande "
 "pour la tâche ci-dessus peut ressembler à ceci :"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
-".0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+".0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: tutorial.md

--- a/po/reuse-docs.it.po
+++ b/po/reuse-docs.it.po
@@ -1449,13 +1449,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.it.po
+++ b/po/reuse-docs.it.po
@@ -1407,19 +1407,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1449,13 +1449,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1494,7 +1494,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1559,14 +1559,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.nb_NO.po
+++ b/po/reuse-docs.nb_NO.po
@@ -1301,19 +1301,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1343,13 +1343,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1388,7 +1388,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1453,14 +1453,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.nb_NO.po
+++ b/po/reuse-docs.nb_NO.po
@@ -1343,13 +1343,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.pot
+++ b/po/reuse-docs.pot
@@ -1333,13 +1333,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.pot
+++ b/po/reuse-docs.pot
@@ -1291,19 +1291,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1333,13 +1333,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1378,7 +1378,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1443,14 +1443,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.pt.po
+++ b/po/reuse-docs.pt.po
@@ -1443,13 +1443,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.pt.po
+++ b/po/reuse-docs.pt.po
@@ -1401,19 +1401,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1443,13 +1443,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1488,7 +1488,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1553,14 +1553,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.pt_BR.po
+++ b/po/reuse-docs.pt_BR.po
@@ -1427,19 +1427,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1469,13 +1469,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1514,7 +1514,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1579,14 +1579,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.pt_BR.po
+++ b/po/reuse-docs.pt_BR.po
@@ -1469,13 +1469,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.ru.po
+++ b/po/reuse-docs.ru.po
@@ -1306,19 +1306,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1348,13 +1348,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1393,7 +1393,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1458,14 +1458,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.ru.po
+++ b/po/reuse-docs.ru.po
@@ -1348,13 +1348,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.sv.po
+++ b/po/reuse-docs.sv.po
@@ -1359,13 +1359,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.sv.po
+++ b/po/reuse-docs.sv.po
@@ -1317,19 +1317,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1359,13 +1359,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1404,7 +1404,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1469,14 +1469,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.tr.po
+++ b/po/reuse-docs.tr.po
@@ -1479,19 +1479,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1521,13 +1521,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1566,7 +1566,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1631,14 +1631,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.tr.po
+++ b/po/reuse-docs.tr.po
@@ -1521,13 +1521,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/po/reuse-docs.uk.po
+++ b/po/reuse-docs.uk.po
@@ -1834,19 +1834,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Якщо цього не сталося, або якщо ви хочете примусово застосувати це, додайте "
-"аргумент `--explicit-license` до команди annotate. Отже, команда для "
+"аргумент `--force-dot-license` до команди annotate. Отже, команда для "
 "вищезазначеного завдання може мати такий вигляд:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
-".0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+".0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
 #: tutorial.md

--- a/po/reuse-docs.uk.po
+++ b/po/reuse-docs.uk.po
@@ -1775,27 +1775,27 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
-"Команда `reuse addheader` допомагає додавати відомості про ліцензії та "
+"Команда `reuse annotate` допомагає додавати відомості про ліцензії та "
 "авторські права до ваших файлів. Для завдання вище, така команда "
 "виконуватиме цю роботу:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-or-later\" src/main.c Makefile README.md\n"
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
-"Перегляньте [документацію засобу про addheader](https://reuse.readthedocs.io/"
-"en/stable/usage.html#addheader), щоб дізнатися про додаткові опції, як-от "
+"Перегляньте [документацію засобу про annotate](https://reuse.readthedocs.io/"
+"en/stable/usage.html#annotate), щоб дізнатися про додаткові опції, як-от "
 "стилі коментарів і шаблони"
 
 #. type: Title ###
@@ -1834,18 +1834,18 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 "Якщо цього не сталося, або якщо ви хочете примусово застосувати це, додайте "
-"аргумент `--explicit-license` до команди addheader. Отже, команда для "
+"аргумент `--explicit-license` до команди annotate. Отже, команда для "
 "вищезазначеного завдання може мати такий вигляд:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3"
 ".0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 
 #. type: Title ###
@@ -1893,10 +1893,10 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 "Наразі засіб не надає способу заміни наявних відомостей про авторські права "
-"та ліцензування, сумісних з REUSE. Запуск команди `addheader` не замінить, а "
+"та ліцензування, сумісних з REUSE. Запуск команди `annotate` не замінить, а "
 "розширить файли `.license` двома додатковими рядками із зазначенням "
 "авторських прав Макса Мела та ліцензії CC-BY-4.0. Таким чином, вам потрібно "
 "оновити їх вручну."
@@ -1987,20 +1987,20 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
-"Як і раніше, комбінація команд `addheader` and `download` виконає наведену "
+"Як і раніше, комбінація команд `annotate` and `download` виконає наведену "
 "раніше дію:"
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1"
 ".0\" .gitignore\n"
 "\n"
 "reuse download --all\n"

--- a/po/reuse-docs.zh_Hans.po
+++ b/po/reuse-docs.zh_Hans.po
@@ -1301,19 +1301,19 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The `reuse addheader` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
+msgid "The `reuse annotate` command helps with adding licensing and copyright information to your files. For the task above, the following command would do the job:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" src/main.c Makefile README.md\n"
 msgstr ""
 
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "Please see the [tool's documentation about addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)  for more options like comment styles and templates"
+msgid "Please see the [tool's documentation about annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)  for more options like comment styles and templates"
 msgstr ""
 
 #. type: Title ###
@@ -1343,13 +1343,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the addheader command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###
@@ -1388,7 +1388,7 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `addheader` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
+msgid "The tool as of now does not provide a way to replace existing REUSE-compliant copyright and licensing information. A run of the `annotate` command would not replace but extend the `.license` files with two additional lines stating the copyright of Max Mehl and the CC-BY-4.0 license. So you would have to update these manually."
 msgstr ""
 
 #. type: Plain text
@@ -1453,14 +1453,14 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "As before, a combination of the `addheader` and `download` commands will fulfil the above step:"
+msgid "As before, a combination of the `annotate` and `download` commands will fulfil the above step:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
 msgid ""
-"reuse addheader --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
+"reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"CC0-1.0\" .gitignore\n"
 "\n"
 "reuse download --all\n"
 msgstr ""

--- a/po/reuse-docs.zh_Hans.po
+++ b/po/reuse-docs.zh_Hans.po
@@ -1343,13 +1343,13 @@ msgstr ""
 #. type: Plain text
 #: tutorial.md
 #, markdown-text
-msgid "If it does not, or if you would like to enforce this, add the `--explicit-license` argument to the annotate command. So the command for the above task may look like this:"
+msgid "If it does not, or if you would like to enforce this, add the `--force-dot-license` argument to the annotate command. So the command for the above task may look like this:"
 msgstr ""
 
 #. type: Fenced code block (bash)
 #: tutorial.md
 #, no-wrap
-msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --explicit-license img/cat.jpg img/dog.jpg\n"
+msgid "reuse annotate --copyright=\"Jane Doe <jane@example.com>\" --license=\"GPL-3.0-or-later\" --force-dot-license img/cat.jpg img/dog.jpg\n"
 msgstr ""
 
 #. type: Title ###

--- a/tutorial.md
+++ b/tutorial.md
@@ -113,16 +113,16 @@ header information, but of course with corresponding comment syntax.
 
 {{< box-tool >}}
 
-The `reuse addheader` command helps with adding licensing and copyright
+The `reuse annotate` command helps with adding licensing and copyright
 information to your files. For the task above, the following command
 would do the job:
 
 ```bash
-reuse addheader --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" src/main.c Makefile README.md
+reuse annotate --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" src/main.c Makefile README.md
 ```
 
 Please see the [tool's documentation about
-addheader](https://reuse.readthedocs.io/en/stable/usage.html#addheader)
+annotate](https://reuse.readthedocs.io/en/stable/usage.html#annotate)
 for more options like comment styles and templates
 
 {{< /box-tool >}}
@@ -144,11 +144,11 @@ The REUSE helper tool should automatically detect binary files and
 therefore automatically create a corresponding `.license` file.
 
 If it does not, or if you would like to enforce this, add the
-`--force-dot-license` argument to the addheader command. So the command
+`--force-dot-license` argument to the annotate command. So the command
 for the above task may look like this:
 
 ```bash
-reuse addheader --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" --force-dot-license img/cat.jpg img/dog.jpg
+reuse annotate --copyright="Jane Doe <jane@example.com>" --license="GPL-3.0-or-later" --force-dot-license img/cat.jpg img/dog.jpg
 ```
 
 {{< /box-tool >}}
@@ -175,7 +175,7 @@ SPDX-License-Identifier: CC-BY-4.0
 
 The tool as of now does not provide a way to replace existing
 REUSE-compliant copyright and licensing information. A run of
-the `addheader` command would not replace but extend the `.license`
+the `annotate` command would not replace but extend the `.license`
 files with two additional lines stating the copyright of Max Mehl and
 the CC-BY-4.0 license. So you would have to update these manually.
 
@@ -218,10 +218,10 @@ More information about copyrightable files can be found in the [REUSE FAQ]({{< r
 
 {{< box-tool >}}
 
-As before, a combination of the `addheader` and `download` commands will fulfil the above step:
+As before, a combination of the `annotate` and `download` commands will fulfil the above step:
 
 ```bash
-reuse addheader --copyright="Jane Doe <jane@example.com>" --license="CC0-1.0" .gitignore
+reuse annotate --copyright="Jane Doe <jane@example.com>" --license="CC0-1.0" .gitignore
 
 reuse download --all
 ```


### PR DESCRIPTION
Updated deprecated commands with their new equivalents:
- `reuse addheader` -> `reuse annotate`
- `--explicit-license` -> `--force-dot-license`